### PR TITLE
Add full-stack ToDo app with React, .NET and Keycloak

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # ToDoApp
-A ToDo list application for windows and linux
+
+Cross-platform ToDo list application with a C# .NET backend and React frontend.
+
+## Components
+
+- **backend**: ASP.NET Core Web API storing user-specific todos in memory.
+- **frontend**: React client using Keycloak for authentication.
+- **Keycloak**: OAuth2 provider configured via Docker.
+
+## Running
+
+1. Start services with Docker Compose:
+
+   ```bash
+   docker compose up --build
+   ```
+
+   This launches Keycloak on [http://localhost:8080](http://localhost:8080), the API on [http://localhost:5000](http://localhost:5000) and the React app on [http://localhost:3000](http://localhost:3000).
+
+2. In Keycloak, create a realm named `todo` with clients `todo-api` (confidential) and `todo-frontend` (public). Users log in via Keycloak and each maintains a separate list.
+
+## Development
+
+The backend requires .NET 8 SDK, and the frontend uses Node 20 with Vite. Both run on Mac or Linux.

--- a/backend/Controllers/TodoController.cs
+++ b/backend/Controllers/TodoController.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using ToDoApp.Models;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class TodoController : ControllerBase
+{
+    private readonly ITodoStore _store;
+
+    public TodoController(ITodoStore store)
+    {
+        _store = store;
+    }
+
+    [HttpGet]
+    public IEnumerable<TodoItem> Get()
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        return _store.GetTodos(userId);
+    }
+
+    [HttpPost]
+    public ActionResult<TodoItem> Post([FromBody] string title)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        var item = _store.AddTodo(userId, title);
+        return Created($"/api/todo/{item.Id}", item);
+    }
+
+    [HttpPut("{id}")]
+    public IActionResult Put(Guid id, [FromBody] bool isComplete)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        _store.UpdateTodo(userId, id, isComplete);
+        return NoContent();
+    }
+
+    [HttpDelete("{id}")]
+    public IActionResult Delete(Guid id)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        _store.DeleteTodo(userId, id);
+        return NoContent();
+    }
+}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 5000
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet restore ToDoApp.csproj
+RUN dotnet publish ToDoApp.csproj -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "ToDoApp.dll"]

--- a/backend/Models/TodoItem.cs
+++ b/backend/Models/TodoItem.cs
@@ -1,0 +1,3 @@
+namespace ToDoApp.Models;
+
+public record TodoItem(Guid Id, string Title, bool IsComplete);

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+}).AddJwtBearer(options =>
+{
+    options.Authority = builder.Configuration["Keycloak:Authority"];
+    options.Audience = builder.Configuration["Keycloak:Audience"];
+    options.RequireHttpsMetadata = false;
+});
+
+builder.Services.AddAuthorization();
+
+builder.Services.AddSingleton<ITodoStore, InMemoryTodoStore>();
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/backend/Services/ITodoStore.cs
+++ b/backend/Services/ITodoStore.cs
@@ -1,0 +1,9 @@
+using ToDoApp.Models;
+
+public interface ITodoStore
+{
+    IEnumerable<TodoItem> GetTodos(string userId);
+    TodoItem AddTodo(string userId, string title);
+    void UpdateTodo(string userId, Guid id, bool isComplete);
+    void DeleteTodo(string userId, Guid id);
+}

--- a/backend/Services/InMemoryTodoStore.cs
+++ b/backend/Services/InMemoryTodoStore.cs
@@ -1,0 +1,38 @@
+using System.Collections.Concurrent;
+using ToDoApp.Models;
+
+public class InMemoryTodoStore : ITodoStore
+{
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<Guid, TodoItem>> _data = new();
+
+    public IEnumerable<TodoItem> GetTodos(string userId)
+    {
+        if (_data.TryGetValue(userId, out var todos))
+            return todos.Values;
+        return Enumerable.Empty<TodoItem>();
+    }
+
+    public TodoItem AddTodo(string userId, string title)
+    {
+        var todo = new TodoItem(Guid.NewGuid(), title, false);
+        var userTodos = _data.GetOrAdd(userId, _ => new ConcurrentDictionary<Guid, TodoItem>());
+        userTodos[todo.Id] = todo;
+        return todo;
+    }
+
+    public void UpdateTodo(string userId, Guid id, bool isComplete)
+    {
+        if (_data.TryGetValue(userId, out var todos) && todos.TryGetValue(id, out var existing))
+        {
+            todos[id] = existing with { IsComplete = isComplete };
+        }
+    }
+
+    public void DeleteTodo(string userId, Guid id)
+    {
+        if (_data.TryGetValue(userId, out var todos))
+        {
+            todos.TryRemove(id, out _);
+        }
+    }
+}

--- a/backend/ToDoApp.csproj
+++ b/backend/ToDoApp.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -1,0 +1,6 @@
+{
+  "Keycloak": {
+    "Authority": "http://localhost:8080/realms/todo",
+    "Audience": "todo-api"
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:22.0.5
+    environment:
+      - KEYCLOAK_ADMIN=admin
+      - KEYCLOAK_ADMIN_PASSWORD=admin
+    command: start-dev
+    ports:
+      - "8080:8080"
+  backend:
+    build: ./backend
+    environment:
+      - ASPNETCORE_URLS=http://+:5000
+    ports:
+      - "5000:5000"
+    depends_on:
+      - keycloak
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install || npm install --legacy-peer-deps
+COPY . .
+EXPOSE 3000
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>ToDo App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "todoapp-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "keycloak-js": "^23.0.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react'
+import keycloak from './keycloak'
+
+function App() {
+  const [todos, setTodos] = useState([])
+  const [title, setTitle] = useState('')
+
+  useEffect(() => {
+    keycloak.init({ onLoad: 'login-required' }).then(authenticated => {
+      if (authenticated) {
+        fetch('/api/todo', {
+          headers: { Authorization: `Bearer ${keycloak.token}` }
+        }).then(r => r.json()).then(setTodos)
+      }
+    })
+  }, [])
+
+  const addTodo = () => {
+    fetch('/api/todo', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${keycloak.token}`
+      },
+      body: JSON.stringify(title)
+    }).then(r => r.json()).then(item => {
+      setTodos([...todos, item])
+      setTitle('')
+    })
+  }
+
+  return (
+    <div>
+      <h1>ToDo List</h1>
+      <input value={title} onChange={e => setTitle(e.target.value)} />
+      <button onClick={addTodo}>Add</button>
+      <ul>
+        {todos.map(t => (
+          <li key={t.id}>{t.title}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default App

--- a/frontend/src/keycloak.js
+++ b/frontend/src/keycloak.js
@@ -1,0 +1,9 @@
+import Keycloak from 'keycloak-js'
+
+const keycloak = new Keycloak({
+  url: 'http://localhost:8080',
+  realm: 'todo',
+  clientId: 'todo-frontend'
+})
+
+export default keycloak

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000
+  }
+})


### PR DESCRIPTION
## Summary
- scaffold ASP.NET Core API with JWT auth via Keycloak and per-user in-memory todo storage
- add React frontend using keycloak-js to login and manage user-specific todos
- provide docker-compose setup to run Keycloak, backend, and frontend

## Testing
- `npm test` (fails: Missing script "test")
- `npm install --ignore-scripts` (fails: 403 Forbidden fetching @vitejs/plugin-react)
- `dotnet build backend` (fails: command not found: dotnet)


------
https://chatgpt.com/codex/tasks/task_e_6895ea38ea68832aba281372c646bb85